### PR TITLE
Enable license retrieval for PingAuthorize

### DIFF
--- a/ping-devops
+++ b/ping-devops
@@ -54,7 +54,7 @@ PING_DEVOPS_STANDARD_VARIABLES="
 ################################################################################
 # Version Info
 ################################################################################
-VERSION="0.7.2"
+VERSION="0.7.3"
 
 ################################################################################
 # Ping Identity tools & config information
@@ -1089,7 +1089,7 @@ generate_license_secret()
   # Getting an evaluation license based on product passed
   if test -n "${_licenseProd}"; then
     case "${_licenseProd}" in
-      pingaccess|pingcentral|pingdatametrics|pingdatasync|pingdatagovernance|pingdatagovernancepap|pingdirectory|pingdirectoryproxy|pingfederate|pingintelligence)
+      pingaccess|pingcentral|pingdatametrics|pingdatasync|pingdatagovernance|pingdatagovernancepap|pingdirectory|pingdirectoryproxy|pingfederate|pingintelligence|pingauthorize|pingauthorizepolicyeditor)
 
         check_for_tool $DOCKER
 


### PR DESCRIPTION
This updates the ping-devops script to 0.7.3 and enables
the `pingauthorize` and `pingauthorizepolicyeditor` identifiers when
retrieving licenses. The ping-devops.pingone script remains unmodified
since it is not being used.

Reviewer: Terry Sigle

JiraIssue: DS-43938